### PR TITLE
Feature - Add option to use custom type(s) of repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+node_modules/
 .env
 repositories.json
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,6 @@
 # TO_RUN           : docker run --rm -it fgribreau/maintainers-convention
 ##
 
-FROM node:6-slim
+FROM node:6-onbuild
+
 MAINTAINER François-Guillaume Ribreau <docker@fgribreau.com>
-
-COPY . /app
-
-WORKDIR /app
-
-RUN npm install
-
-CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,22 @@
 
 #### Usage
 
-Run the guard tool daily in your favorite job runner (e.g. Jenkins or Rundeck) with:
+Run the guard tool daily in your favorite job runner (e.g. [Jenkins](https://jenkins.io/) or [Rundeck](http://rundeck.org/)) with:
 
 ```
 docker run --rm -it \
   -e GITHUB_TOKEN=YOUR_GITHUB_TOKEN \
   -e GITHUB_ORGANISATION=YOUR_GITHUB_ORG_NAME fgribreau/maintainers-convention
+  -e REPOS_TYPE=all
 ```
+
+##### About `REPOS_TYPE`
+
+*Note: `REPOS_TYPE` is optional (default: "all").*
+
+Possible values: `all, public, private, forks, sources, member`.
+
+[Github API Docs](https://developer.github.com/v3/repos/#list-organization-repositories)
 
 ### Todo:
 

--- a/guard-run.js
+++ b/guard-run.js
@@ -7,6 +7,9 @@ const config = require('common-env')(console).getOrElseAll({
   },
   maintainers: {
     filename: 'MAINTAINERS'
+  },
+  repos: {
+    type: 'all'
   }
 });
 

--- a/src/getRepos.js
+++ b/src/getRepos.js
@@ -5,7 +5,7 @@ const _ = require('lodash');
 const when = require('when');
 
 // String -> String -> Promise[Err, Array[Repository]]
-function getRepos(organisation, token) {
+function getRepos(organisation, token, type) {
   return when.promise((resolve, reject) => {
     async.foldUntil({
       repositories: [],
@@ -13,7 +13,7 @@ function getRepos(organisation, token) {
     }, function iterator(memo, next, stop) {
       github('get', memo.url, {
         access_token: token,
-        type: 'all',
+        type: type,
         per_page: 100
       }, function(err, resp, repositories) {
         if (err) {

--- a/src/guard.js
+++ b/src/guard.js
@@ -17,8 +17,9 @@ module.exports = function(config) {
   assert(_.isString(config.github.organisation));
   assert(_.isString(config.github.token));
   assert(_.isString(config.maintainers.filename));
+  assert(_.isString(config.repos.type));
 
-  const repositories = getRepos(config.github.organisation, config.github.token);
+  const repositories = getRepos(config.github.organisation, config.github.token, config.repos.type);
   // const repositories = when(JSON.parse(require('fs').readFileSync(require('path').resolve(__dirname, '../repositories.json'), 'utf8')));
 
 


### PR DESCRIPTION
Hello,

Small Pull Request that add an option to use custom type(s) of repos.
https://developer.github.com/v3/repos/#list-organization-repositories

For e.g. if you must check, only sources... set `REPOS_TYPE` to `sources`.

This PR is offer with ❤️ 
